### PR TITLE
fix telescope button import for case sensitive OS

### DIFF
--- a/electron-react-app/src/renderer/components/TelescopeButton.tsx
+++ b/electron-react-app/src/renderer/components/TelescopeButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@nextui-org/button';
 import TelescopeIcon from './Icons/TelescopeIcon';
-import './telescope.css';
+import './Telescope.css';
 
 function TelescopeButton(props: any) {
   return (


### PR DESCRIPTION
The electron app won't build on case sensitive operating systems without this fix.

During `npm run package` on linux:

```log
[0] npm run build:main exited with code 0
[1] ERROR in ./src/renderer/components/TelescopeButton.tsx 3:0-25
[1] Module not found: Error: Can't resolve './telescope.css' in '/home/fpreiss/Downloads/github/llama-fs/electron-react-app/src/renderer/components'
```