### PR TITLE
Handle files without text

### DIFF
--- a/src/loader.py
+++ b/src/loader.py
@@ -65,8 +65,14 @@ def load_documents(path: str):
         # By default, llama index split files into multiple "documents"
         if len(docs) > 1:
             # So we first join all the document contexts, then truncate by token count
-            text = splitter.split_text("\n".join([d.text for d in docs]))[0]
-            documents.append(Document(text=text, metadata=docs[0].metadata))
+            for d in docs:
+                # Some files will not have text and need to be handled
+                contents = splitter.split_text("\n".join(d.text))
+                if len(contents) > 0:
+                    text = contents[0]
+                else:
+                    text = ""
+                documents.append(Document(text=text, metadata=docs[0].metadata))
         else:
             documents.append(docs[0])
     return documents


### PR DESCRIPTION
Closes #38 

Some documents have no text in the document. The original code had no handling for this, and would crash if there was no text. This allows for a clean handling of these files without a try - except block.

Tested on Fedora 40 and Bazzite, seems to function with no issues.