### PR TITLE
Change "devEngines" to "engines" in package.json

### DIFF
--- a/electron-react-app/package.json
+++ b/electron-react-app/package.json
@@ -244,7 +244,7 @@
   "collective": {
     "url": "https://opencollective.com/electron-react-boilerplate-594"
   },
-  "devEngines": {
+  "engines": {
     "node": ">=14.x",
     "npm": ">=7.x"
   },


### PR DESCRIPTION
"devEngines" as was used here should be "engines." As far as I can tell, this was always wrong, but npm<=9 just ignored it. https://docs.npmjs.com/cli/v11/configuring-npm/package-json #

#71 