### PR TITLE
Add specific agentops version and fastapi[standard]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,9 @@ termcolor
 click
 asciitree
 fastapi
+fastapi[standard]
 weave
-agentops
+agentops==0.3.26
 langchain
 langchain_core
 watchdog


### PR DESCRIPTION
AgentOps > 0.4 doesn't seem to work, and I had to install fastapi[standard] as well to get the server to work.