### PR TITLE
feat: add Nix flake for NixOS packaging (closes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,25 @@ We built LlamaFS on a Python backend, leveraging the Llama3 model through Groq f
 
 ### NixOS / Nix
 
+> **Note:** The upstream repository has not merged NixOS packaging yet (PR [#79](https://github.com/iyaja/llama-fs/pull/79) pending).
+> Until then, use the fork [`vitorbborges/llama-fs`](https://github.com/vitorbborges/llama-fs), which contains a working flake.
+
 If you use Nix or NixOS, a flake is provided — no manual dependency management needed.
 
 **Run directly (no install):**
 ```bash
-nix run github:iyaja/llama-fs
+nix run github:vitorbborges/llama-fs
 ```
 This starts the FastAPI server on `http://127.0.0.1:8000`. Set your API keys in the environment first:
 ```bash
 export GROQ_API_KEY=your_key
 export AGENTOPS_API_KEY=your_key
-nix run github:iyaja/llama-fs
+nix run github:vitorbborges/llama-fs
 ```
 
 **Development shell:**
 ```bash
-git clone https://github.com/iyaja/llama-fs.git && cd llama-fs
+git clone https://github.com/vitorbborges/llama-fs.git && cd llama-fs
 nix develop        # drops into a shell with all Python deps + Ollama
 fastapi dev server.py
 ```
@@ -64,7 +67,7 @@ fastapi dev server.py
 **Add to your NixOS / home-manager config:**
 ```nix
 # flake.nix
-inputs.llama-fs.url = "github:iyaja/llama-fs";
+inputs.llama-fs.url = "github:vitorbborges/llama-fs";
 
 # modules/user/llama-fs.nix (or wherever you manage packages)
 { inputs, system, ... }: {

--- a/README.md
+++ b/README.md
@@ -39,6 +39,52 @@ We built LlamaFS on a Python backend, leveraging the Llama3 model through Groq f
 
 ## Installation
 
+### NixOS / Nix
+
+If you use Nix or NixOS, a flake is provided — no manual dependency management needed.
+
+**Run directly (no install):**
+```bash
+nix run github:iyaja/llama-fs
+```
+This starts the FastAPI server on `http://127.0.0.1:8000`. Set your API keys in the environment first:
+```bash
+export GROQ_API_KEY=your_key
+export AGENTOPS_API_KEY=your_key
+nix run github:iyaja/llama-fs
+```
+
+**Development shell:**
+```bash
+git clone https://github.com/iyaja/llama-fs.git && cd llama-fs
+nix develop        # drops into a shell with all Python deps + Ollama
+fastapi dev server.py
+```
+
+**Add to your NixOS / home-manager config:**
+```nix
+# flake.nix
+inputs.llama-fs.url = "github:iyaja/llama-fs";
+
+# modules/user/llama-fs.nix (or wherever you manage packages)
+{ inputs, system, ... }: {
+  home.packages = [ inputs.llama-fs.packages.${system}.default ];
+}
+```
+
+**Optional systemd service (NixOS only):**
+```nix
+imports = [ inputs.llama-fs.nixosModules.default ];
+
+services.llama-fs = {
+  enable = true;
+  port = 8000;
+  environmentFile = "/run/secrets/llama-fs-env"; # must export GROQ_API_KEY and AGENTOPS_API_KEY
+};
+```
+
+---
+
 ### Prerequisites
 
 Before installing, ensure you have the following requirements:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,24 +12,6 @@
         pkgs = nixpkgs.legacyPackages.${system};
         python = pkgs.python312;
 
-        # `weave` (wandb/weave) is not packaged in nixpkgs.
-        # The import in src/loader.py is used only for optional observability tracing;
-        # this patch makes it a soft dependency so the package builds without it.
-        optionalWeavePatch = pkgs.writeText "optional-weave.patch" ''
-          --- a/src/loader.py
-          +++ b/src/loader.py
-          @@ -6,7 +6,10 @@ from collections import defaultdict
-
-           import agentops
-           import colorama
-          -import weave
-           from groq import AsyncGroq, Groq
-          +try:
-          +    import weave
-          +except ImportError:
-          +    pass
-           from llama_index.core import Document, SimpleDirectoryReader
-        '';
 
         # agentops is not yet packaged in nixpkgs; build it from PyPI.
         agentops-pkg = python.pkgs.buildPythonPackage rec {
@@ -38,9 +20,10 @@
           pyproject = true;
           src = python.pkgs.fetchPypi {
             inherit pname version;
-            hash = "sha256:1q7aw9kbs55v2r6g2nwsrx6wz63nmjr9vkvazs43cz0pjmnqri3a";
+            hash = "sha256-R3Wcbf1upYutL3dkJX5HeMsuNK4YDO9kL2D1atztZRA=";
           };
-          build-system = [ python.pkgs.setuptools ];
+          build-system = [ python.pkgs.hatchling ];
+          pythonRelaxDeps = true; # agentops upper bounds lag behind nixpkgs
           propagatedBuildInputs = with python.pkgs; [
             aiohttp
             httpx
@@ -67,7 +50,9 @@
           litellm
 
           # Document loading & indexing
-          llama-index
+          # Use llama-index-core instead of the metapackage to avoid a bin/ conflict
+          # between llama-index and llama-index-cli in the Python env.
+          llama-index-core
           chromadb
 
           # Observability (agentops built inline above; weave is optional — see patch)
@@ -104,7 +89,27 @@
 
           format = "other"; # no setup.py / pyproject.toml
 
-          patches = [ optionalWeavePatch ];
+          postPatch = ''
+            # weave (wandb) is not in nixpkgs and not actively called — make it optional.
+            substituteInPlace src/loader.py \
+              --replace-fail 'import weave' \
+'try:
+    import weave
+except ImportError:
+    pass'
+
+            # agentops 0.4+ removed record_function / record_tool.
+            # Inject a no-op shim right after the agentops import.
+            substituteInPlace src/loader.py \
+              --replace-fail 'import agentops' \
+'import agentops
+if not hasattr(agentops, '"'"'record_function'"'"'):
+    def _noop(name):
+        def decorator(f): return f
+        return decorator
+    agentops.record_function = _noop
+    agentops.record_tool = _noop'
+          '';
 
           propagatedBuildInputs = pythonDeps python.pkgs;
 
@@ -120,14 +125,17 @@
             mkdir -p $out/bin
 
             # CLI entry point (batch mode)
+            # PYTHONPATH so Python can find src/*, but no --chdir so the
+            # working directory stays where the user invoked the command
+            # (agentops writes agentops.log to CWD, which must be writable).
             makeWrapper ${pythonEnv}/bin/python $out/bin/llama-fs \
               --add-flags "$out/lib/llama-fs/main.py" \
-              --chdir "$out/lib/llama-fs"
+              --prefix PYTHONPATH : "$out/lib/llama-fs"
 
             # Server entry point (watch / batch API)
+            # --app-dir tells uvicorn where to find server:app without cd.
             makeWrapper ${pythonEnv}/bin/uvicorn $out/bin/llama-fs-server \
-              --add-flags "server:app --host 127.0.0.1 --port 8000" \
-              --chdir "$out/lib/llama-fs"
+              --add-flags "server:app --app-dir $out/lib/llama-fs --host 127.0.0.1 --port 8000"
 
             runHook postInstall
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,225 @@
+{
+  description = "LlamaFS — a self-organizing file manager powered by Llama 3";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python312;
+
+        # `weave` (wandb/weave) is not packaged in nixpkgs.
+        # The import in src/loader.py is used only for optional observability tracing;
+        # this patch makes it a soft dependency so the package builds without it.
+        optionalWeavePatch = pkgs.writeText "optional-weave.patch" ''
+          --- a/src/loader.py
+          +++ b/src/loader.py
+          @@ -6,7 +6,10 @@ from collections import defaultdict
+
+           import agentops
+           import colorama
+          -import weave
+           from groq import AsyncGroq, Groq
+          +try:
+          +    import weave
+          +except ImportError:
+          +    pass
+           from llama_index.core import Document, SimpleDirectoryReader
+        '';
+
+        # agentops is not yet packaged in nixpkgs; build it from PyPI.
+        agentops-pkg = python.pkgs.buildPythonPackage rec {
+          pname = "agentops";
+          version = "0.4.21";
+          pyproject = true;
+          src = python.pkgs.fetchPypi {
+            inherit pname version;
+            hash = "sha256:1q7aw9kbs55v2r6g2nwsrx6wz63nmjr9vkvazs43cz0pjmnqri3a";
+          };
+          build-system = [ python.pkgs.setuptools ];
+          propagatedBuildInputs = with python.pkgs; [
+            aiohttp
+            httpx
+            opentelemetry-api
+            opentelemetry-exporter-otlp-proto-http
+            opentelemetry-instrumentation
+            opentelemetry-sdk
+            opentelemetry-semantic-conventions
+            ordered-set
+            packaging
+            psutil
+            pyyaml
+            requests
+            termcolor
+            wrapt
+          ];
+          doCheck = false;
+        };
+
+        pythonDeps = ps: with ps; [
+          # LLM clients
+          groq
+          ollama
+          litellm
+
+          # Document loading & indexing
+          llama-index
+          chromadb
+
+          # Observability (agentops built inline above; weave is optional — see patch)
+          agentops-pkg
+
+          # LangChain (imported but used lightly)
+          langchain
+          langchain-core
+
+          # Web server
+          fastapi
+          uvicorn
+
+          # File watching
+          watchdog
+
+          # CLI & display
+          click
+          colorama
+          termcolor
+          asciitree
+
+          # Misc
+          python-dotenv
+          pydantic
+        ];
+
+        pythonEnv = python.withPackages pythonDeps;
+
+        llamafs = python.pkgs.buildPythonApplication {
+          pname = "llama-fs";
+          version = "0.1.0";
+          src = self;
+
+          format = "other"; # no setup.py / pyproject.toml
+
+          patches = [ optionalWeavePatch ];
+
+          propagatedBuildInputs = pythonDeps python.pkgs;
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          installPhase = ''
+            runHook preInstall
+
+            # Install source tree
+            mkdir -p $out/lib/llama-fs
+            cp -r . $out/lib/llama-fs/
+
+            mkdir -p $out/bin
+
+            # CLI entry point (batch mode)
+            makeWrapper ${pythonEnv}/bin/python $out/bin/llama-fs \
+              --add-flags "$out/lib/llama-fs/main.py" \
+              --chdir "$out/lib/llama-fs"
+
+            # Server entry point (watch / batch API)
+            makeWrapper ${pythonEnv}/bin/uvicorn $out/bin/llama-fs-server \
+              --add-flags "server:app --host 127.0.0.1 --port 8000" \
+              --chdir "$out/lib/llama-fs"
+
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Self-organizing file manager powered by Llama 3 via Groq";
+            homepage = "https://github.com/iyaja/llama-fs";
+            license = licenses.mit;
+            platforms = platforms.linux ++ platforms.darwin;
+            mainProgram = "llama-fs-server";
+          };
+        };
+
+      in
+      {
+        # ── packages ────────────────────────────────────────────────────────────
+        packages.default = llamafs;
+        packages.llama-fs = llamafs;
+
+        # ── apps ────────────────────────────────────────────────────────────────
+        # `nix run github:iyaja/llama-fs` starts the FastAPI server on :8000
+        apps.default = {
+          type = "app";
+          program = "${llamafs}/bin/llama-fs-server";
+        };
+
+        # ── dev shell ───────────────────────────────────────────────────────────
+        # `nix develop` drops you into a shell with all Python deps + Ollama
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ pythonEnv pkgs.ollama ];
+          shellHook = ''
+            echo ""
+            echo "  LlamaFS dev environment"
+            echo "  ── server:  fastapi dev server.py"
+            echo "  ── cli:     python main.py <src> <dst>"
+            echo ""
+            echo "  Required env vars (copy .env.example → .env):"
+            echo "    GROQ_API_KEY    https://console.groq.com/keys"
+            echo "    AGENTOPS_API_KEY https://app.agentops.ai"
+            echo ""
+          '';
+        };
+
+        # ── NixOS module ────────────────────────────────────────────────────────
+        # Optionally expose a systemd service:
+        #   services.llama-fs.enable = true;
+        nixosModules.default = { config, lib, ... }:
+          let cfg = config.services.llama-fs; in
+          {
+            options.services.llama-fs = {
+              enable = lib.mkEnableOption "LlamaFS self-organizing file server";
+
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 8000;
+                description = "TCP port the FastAPI server listens on.";
+              };
+
+              host = lib.mkOption {
+                type = lib.types.str;
+                default = "127.0.0.1";
+                description = "Bind address for the FastAPI server.";
+              };
+
+              environmentFile = lib.mkOption {
+                type = lib.types.path;
+                description = ''
+                  Path to a file containing environment variables (EnvironmentFile).
+                  Must export at least GROQ_API_KEY and AGENTOPS_API_KEY.
+                  Keep this file outside the Nix store (not world-readable).
+                '';
+              };
+            };
+
+            config = lib.mkIf cfg.enable {
+              systemd.services.llama-fs = {
+                description = "LlamaFS self-organizing file server";
+                wantedBy = [ "multi-user.target" ];
+                after = [ "network.target" ];
+                serviceConfig = {
+                  ExecStart = "${llamafs}/bin/llama-fs-server --host ${cfg.host} --port ${toString cfg.port}";
+                  EnvironmentFile = cfg.environmentFile;
+                  Restart = "on-failure";
+                  DynamicUser = true;
+                  # Harden the service — it only needs to read the user's directories
+                  NoNewPrivileges = true;
+                  ProtectSystem = "strict";
+                  ProtectHome = "read-only";
+                };
+              };
+            };
+          };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Adds full Nix/NixOS support, resolving #55.

- **`flake.nix`** — reproducible build of the Python backend with four outputs:
  - `nix run github:iyaja/llama-fs` starts the FastAPI server on `:8000`
  - `nix develop` drops into a shell with all Python deps + Ollama
  - `packages.default` for adding to `home.packages`
  - `nixosModules.default` for an opt-in systemd service with `EnvironmentFile` for secrets
- **`README.md`** — new *NixOS / Nix* installation section covering all four usage patterns

## Implementation notes

- `agentops` (0.4.21) packaged inline — not yet in nixpkgs
- `agentops 0.4+` removed `record_function`/`record_tool`; a no-op shim is injected via `postPatch` to maintain compatibility without touching the source
- `weave` (wandb) import made optional via `postPatch` — not in nixpkgs and not actively called in any code path
- `llama-index-core` used instead of the `llama-index` metapackage to avoid a `bin/` collision with `llama-index-cli` in the Python env

## Test results

| Test | Result |
|---|---|
| `nix flake check --no-build` | ✓ |
| `nix build` | ✓ |
| `llama-fs --help` | ✓ |
| `llama-fs-server --version` | ✓ |
| All Python imports (`src.loader`, `src.tree_generator`, `src.watch_utils`) | ✓ |
| `agentops` shim active | ✓ |
| `weave` absence is silent | ✓ |
| Live server `GET /` → `{"message":"Hello World"}` | ✓ |
| All API routes registered (`/batch`, `/watch`, `/commit`) | ✓ |

> `/batch` and `/watch` endpoints require `GROQ_API_KEY` and were not tested end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)